### PR TITLE
RK-18079 - bump rook version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ class Download extends DefaultTask {
 
 
 task downloadRookout(type: Download) {
-    sourceUrl = "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.rookout&a=rook&v=0.1.247"
+    sourceUrl = "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.rookout&a=rook&v=0.1.251"
     target = new File('rook.jar')
 }
 


### PR DESCRIPTION
Publish CI isn't updating this.
@alexeygutkin let's add it to the java rook publish demo update step.